### PR TITLE
Add services overview styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -350,6 +350,29 @@
             margin-bottom: 1rem;
             font-size: 1.3rem;
         }
+        /* Services overview section */
+        .services-overview {
+            padding: 80px 0;
+        }
+        .services-overview .container {
+            background: rgba(255, 255, 255, 0.05);
+            padding: 3rem;
+            border-radius: 20px;
+            text-align: center;
+        }
+        .services-overview h2 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+            color: #e0e0e0;
+        }
+        .services-overview p {
+            font-size: 1.1rem;
+            max-width: 700px;
+            margin-left: auto;
+            margin-right: auto;
+            opacity: 0.9;
+        }
+
 
         /* Detailed service blocks on the Services page */
         .service-detail {


### PR DESCRIPTION
## Summary
- style the Services overview section for consistent layout
- run the static site build

## Testing
- `python3 build.py`


------
https://chatgpt.com/codex/tasks/task_e_6846130bc5f8833090735c32d10cfa2d