### PR TITLE
Fix timeline dots overlapping headings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -957,6 +957,15 @@
             z-index: 1; /* keep content above decorative dot */
         }
 
+        /* add breathing room so the decorative dots don't overlap nearby text */
+        .timeline-item:first-child {
+            margin-top: 1rem;
+        }
+
+        .timeline-item:last-child {
+            margin-bottom: 1rem;
+        }
+
         .timeline-item::before {
             content: '';
             position: absolute;


### PR DESCRIPTION
## Summary
- add margin to the first and last timeline items so that their decorative dots do not collide with nearby text

## Testing
- `python3 build.py`


------
https://chatgpt.com/codex/tasks/task_e_684623fd91cc83308cb92ad613006b75