### PR TITLE
Improve animations and navigation

### DIFF
--- a/case-studies.html
+++ b/case-studies.html
@@ -277,6 +277,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>

--- a/css/styles.css
+++ b/css/styles.css
@@ -77,6 +77,14 @@
             color: #50e3c2;
         }
 
+        .nav-links a.active {
+            color: #50e3c2;
+        }
+
+        .nav-links a.active::after {
+            width: 100%;
+        }
+
         .hamburger {
             display: none;
             flex-direction: column;
@@ -1087,6 +1095,27 @@
             background: linear-gradient(90deg, #00b894, #50e3c2);
             z-index: 1001;
             transition: width 0.3s ease;
+        }
+
+        .back-to-top {
+            position: fixed;
+            bottom: 40px;
+            right: 40px;
+            width: 40px;
+            height: 40px;
+            border: none;
+            border-radius: 50%;
+            background: #50e3c2;
+            color: #0a0a0a;
+            cursor: pointer;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        .back-to-top:hover {
+            background: #3bc9a4;
         }
 
         /* Mobile Responsiveness */

--- a/experience.html
+++ b/experience.html
@@ -470,6 +470,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -157,6 +157,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -223,6 +223,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -34,7 +34,10 @@ window.addEventListener('DOMContentLoaded', () => {
             const target = document.querySelector(href);
             if (target) {
                 e.preventDefault();
-                target.scrollIntoView({behavior: 'smooth', block: 'start'});
+                const header = document.querySelector('header');
+                const offset = header ? header.offsetHeight : 0;
+                const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
+                window.scrollTo({top, behavior: 'smooth'});
             }
         });
     });
@@ -44,8 +47,7 @@ window.addEventListener('DOMContentLoaded', () => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
                 entry.target.classList.add('visible');
-            } else {
-                entry.target.classList.remove('visible');
+                observer.unobserve(entry.target);
             }
         });
     }, observerOptions);
@@ -63,6 +65,27 @@ window.addEventListener('DOMContentLoaded', () => {
     stats.forEach((stat, index) => {
         stat.style.transitionDelay = `${index * 0.2}s`;
     });
+
+    const sections = document.querySelectorAll('section[id]');
+    const navAnchors = document.querySelectorAll('#navLinks a[href^="#"]');
+    const navMap = {};
+    navAnchors.forEach(link => {
+        const id = link.getAttribute('href').substring(1);
+        navMap[id] = link;
+    });
+    const sectionObserver = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const id = entry.target.getAttribute('id');
+                const active = navMap[id];
+                if (active) {
+                    navAnchors.forEach(a => a.classList.remove('active'));
+                    active.classList.add('active');
+                }
+            }
+        });
+    }, {threshold: 0.6});
+    sections.forEach(section => sectionObserver.observe(section));
 
     const contactForm = document.querySelector('.contact-form');
     if (contactForm) {
@@ -108,6 +131,13 @@ window.addEventListener('DOMContentLoaded', () => {
             });
         });
     }
+
+    const backToTop = document.getElementById('backToTop');
+    if (backToTop) {
+        backToTop.addEventListener('click', () => {
+            window.scrollTo({top: 0, behavior: 'smooth'});
+        });
+    }
 });
 
 window.addEventListener('scroll', () => {
@@ -120,6 +150,11 @@ window.addEventListener('scroll', () => {
         const total = document.body.scrollHeight - window.innerHeight;
         const progress = (window.pageYOffset / total) * 100;
         progressBar.style.width = progress + '%';
+    }
+
+    const backToTop = document.getElementById('backToTop');
+    if (backToTop) {
+        backToTop.style.display = window.scrollY > 200 ? 'flex' : 'none';
     }
     /* Removed parallax effect on the services hero to prevent flicker */
 });

--- a/services.html
+++ b/services.html
@@ -318,6 +318,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -29,6 +29,7 @@
             </a>
         </div>
     </div>
+    <button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 </footer>
 <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- stop observing animated elements after they become visible so animations run once
- account for header height when smooth scrolling to anchors
- highlight the active section in the nav while scrolling
- add a back-to-top button and styling

## Testing
- `python3 build.py`

------
https://chatgpt.com/codex/tasks/task_e_6846261c85288330898abff510b3c85b